### PR TITLE
[Frame_fixes | Cohan planner | Launch files fixes]

### DIFF
--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -117,6 +117,10 @@
     <node pkg="arena-simulation-setup" name="map_generator_node" type="map_generator_node.py" />
   </group> -->
 
+  <include file="$(find arena_bringup)/launch/testing/sensor_sim.launch">
+
+  </include>
+
   <node type="create_config_file.py" pkg="rviz_utils" name="rviz_config_file_creator" />
   
   <node type="visualize_robot_model.py" pkg="rviz_utils" name="visualize_robot_model" output="screen" />

--- a/arena_bringup/launch/testing/move_base/move_base_aio.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_aio.launch
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
 	<arg name="model" default="burger"/>
+    <arg name="cmd_vel_topic" default="cmd_vel"/>
+    <arg name="odom_topic" default="odom"/>
+    <arg name="namespace" />
 	<param name="robot_model" value="$(arg model)" />
 
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
@@ -13,7 +16,7 @@
 
 	<!-- Node to publish static scan (only based on robot position and map) -->
 	<node name="light_scan_sim" pkg="light_scan_sim" type="light_scan_sim_node" output="screen">
-		<param name="laser/topic" value="/static_scan" />
+		<param name="laser/topic" value="static_scan" />
 		<param name="laser/hz" value="20" />
 		<param name="laser/noise" value="0.0" />
 		<rosparam file="$(find all_in_one_planner)/light_scan_sim/scan_configs/$(arg model)_params.yaml" command="load" />

--- a/arena_bringup/launch/testing/move_base/move_base_applr.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_applr.launch
@@ -5,7 +5,7 @@
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
-
+  <arg name="namespace" />
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
     <param name="base_global_planner" type="string" value="navfn/NavfnROS" />

--- a/arena_bringup/launch/testing/move_base/move_base_arena.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_arena.launch
@@ -2,6 +2,9 @@
 <launch>
     <!-- <arg name="speed" default="0.22"/> -->
     <arg name="model" default="burger" />
+    <arg name="cmd_vel_topic" default="cmd_vel"/>
+    <arg name="odom_topic" default="odom"/>
+    <arg name="namespace" />
     <param name="bool_goal_reached" value="true" />
 
     <!-- move_base -->
@@ -19,9 +22,11 @@
 
     <!-- Launch neural net ros wrapper -->
     <node pkg="arena-ros" type="play_agent.py" name="arena_node" output="screen"/>
-    <!-- <node pkg="arena-ros" type="arena_node_tb3.py" name="arena_node" output="screen" ns="/arena" /> -->
+    <!-- <node pkg="arena-ros" type="arena_node_tb3.py" name="arena_node" output="screen" /> -->
     <!-- spacial_horizon -->
     <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base/NavfnROS/make_plan" />
     </node>
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_cadrl.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_cadrl.launch
@@ -2,6 +2,9 @@
 <launch>
     <!-- move base -->
     <arg name="model" default="burger"/>
+    <arg name="cmd_vel_topic" default="cmd_vel"/>
+    <arg name="odom_topic" default="odom"/>
+    <arg name="namespace" />
     <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/local_costmap_params.yaml" command="load" />
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/global_costmap_params.yaml" command="load" />
@@ -13,11 +16,11 @@
     <arg name="speed" default="1.5"/>
     <arg name="file" default="cadrl_node_tb3.py"/>
     <!-- Launch neural net ros wrapper -->
-    <node pkg="cadrl-ros" type="cadrl_node_tb3.py" name="cadrl_node" output="screen" ns="/cadrl">
+    <node pkg="cadrl-ros" type="cadrl_node_tb3.py" name="cadrl_node" output="screen">
 
         <!-- Publications -->
         <remap from="~other_vels" to="other_vels"/>
-        <remap from="~nn_cmd_vel" to="/cmd_vel"/>
+        <remap from="~nn_cmd_vel" to="cmd_vel"/>
         <remap from="~pose_marker" to="pose_marker"/>
         <remap from="~path_marker" to="path_marker"/>
         <remap from="~goal_path_marker" to="goal_path_marker"/>
@@ -25,12 +28,12 @@
         <remap from="~agent_markers" to="other_agents_markers"/>
 
         <!-- Subscriptions -->
-        <remap from="~pose" to="/odom"/>
+        <remap from="~pose" to="odom"/>
         <remap from="~velocity" to="velocity"/>
         <remap from="~safe_actions" to="local_path_finder/safe_actions"/>
         <remap from="~planner_mode" to="planner_fsm/mode"/>
-        <remap from="~goal" to="/goal"/>
-        <remap from="~subgoal" to="/subgoal"/>
+        <remap from="~goal" to="move_base_simple/goal"/>
+        <remap from="~subgoal" to="subgoal"/>
         <remap from="~clusters" to="/obst_odom"/>
         <remap from="~peds" to="ped_manager/ped_recent"/>
 
@@ -42,6 +45,8 @@
      <!-- spacial_horizon -->
      <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base/NavfnROS/make_plan" />
     </node>
 
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_cohan.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_cohan.launch
@@ -6,52 +6,52 @@
   <arg name="odom_topic" default="odom" />
   <arg name="speed" default="0.22"/>
   <arg name="namespace" />
-  <arg name="node_start_delay" default="5.0" />
 
   <!-- move_base -->
-  <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' ">
+  <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
+    <param name="ns" value="$(arg namespace)" />
     <param name="base_global_planner" value="global_planner/GlobalPlanner" />
     <param name="base_local_planner" value="hateb_local_planner/HATebLocalPlannerROS" />
     <param name="GlobalPlanner/allow_unknown" value="true" />
+    
+    <!-- Load usual move base params -->
     <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/local_costmap_params.yaml" command="load" />
     <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/global_costmap_params.yaml" command="load" />
     <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/hateb_local_planner_params.yaml" command="load"  ns="HATebLocalPlannerROS"/>
     <rosparam file="$(find arena-simulation-setup)/move_base/move_base_params.yaml" command="load" />
 
+    <!-- Load specific hateb costmap params -->
+    <rosparam file="$(find cohan_layers)/cfg/local_costmap_params.yaml" command="load" />
+    <rosparam file="$(find cohan_layers)/cfg/global_costmap_params.yaml" command="load" />
+    
     <!-- planner params -->
     <remap from="cmd_vel" to="$(arg cmd_vel_topic)"/>
     <remap from="odom" to="$(arg  odom_topic)"/>
-    <remap from="/move_base/HATebLocalPlannerROS/agents_states" to="/$(arg namespace)/move_base/HATebLocalPlannerROS/agents_states" />
-    <remap from="/move_base/GlobalPlanner/make_plan" to="/$(arg namespace)/move_base/GlobalPlanner/make_plan"/>
+    <remap from="/move_base/HATebLocalPlannerROS/agents_states" to="$(arg namespace)/move_base/HATebLocalPlannerROS/agents_states" />
+    <remap from="/move_base/GlobalPlanner/make_plan" to="$(arg namespace)/move_base/GlobalPlanner/make_plan"/>
     <param name="base_local_planner" value="hateb_local_planner/HATebLocalPlannerROS" />
-    <!-- <param name="GlobalPlanner/allow_unknown" value="true" /> -->
+    <param name="GlobalPlanner/allow_unknown" value="true" />
   </node>
 
-
-  <!-- With namespace -->
-  <group unless="$(eval ''==arg('namespace'))">
     <!-- Stage agents to /tracked_agents -->
     <node name="agents" pkg="cohan_layers" type="agents_bridge.py" output="screen"/>
 
     <!-- agent pose prediction, for the local-planning -->
     <node pkg="agent_path_prediction" type="agent_path_prediction" name="agent_path_predict" output="screen" >
       <remap from="map" to="/map"/>
-      <remap from="/$(arg namespace)/agent_path_predict/tracked_agents" to="/tracked_agents"/>
-      <remap from="/$(arg namespace)/agent_path_predict/external_agent_trajs" to="/move_base_node/HATebLocalPlannerROS/agent_local_trajs"/>
+      <remap from="$(arg namespace)/agent_path_predict/tracked_agents" to="/tracked_agents"/>
+      <remap from="$(arg namespace)/agent_path_predict/external_agent_trajs" to="/move_base_node/HATebLocalPlannerROS/agent_local_trajs"/>
 
       <param name="velobs_mul" value="1.0"/>
       <param name="velscale_mul" value="2.0"/>
-      <!-- <param name="~robot_frame_id" value="burger_0_0_base_footprint"/> -->
     </node>
 
     <node pkg="agent_path_prediction" type="predict_goal.py" name="agent_goal_predict" output="screen">
-      <remap from="/tracked_agents" to="/$(arg namespace)/tracked_agents"/>
     </node>
 
     <!-- Filter the agents from laser scan -->
     <include file="$(find cohan_layers)/launch/agent_filter.launch">
-      <arg name="simulator" value="stage"/>
       <arg name="namespace" value="$(arg namespace)"/>
     </include>
-  </group>
+
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_cohan.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_cohan.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- Arguments -->
+  <arg name="model" default="burger"/>
+  <arg name="cmd_vel_topic" default="/cmd_vel" />
+  <arg name="odom_topic" default="odom" />
+  <arg name="speed" default="0.22"/>
+  <arg name="namespace" />
+  <arg name="node_start_delay" default="5.0" />
+
+  <!-- move_base -->
+  <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' ">
+    <param name="base_global_planner" value="global_planner/GlobalPlanner" />
+    <param name="base_local_planner" value="hateb_local_planner/HATebLocalPlannerROS" />
+    <param name="GlobalPlanner/allow_unknown" value="true" />
+    <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/local_costmap_params.yaml" command="load" />
+    <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/global_costmap_params.yaml" command="load" />
+    <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/hateb_local_planner_params.yaml" command="load"  ns="HATebLocalPlannerROS"/>
+    <rosparam file="$(find arena-simulation-setup)/move_base/move_base_params.yaml" command="load" />
+
+    <!-- planner params -->
+    <remap from="cmd_vel" to="$(arg cmd_vel_topic)"/>
+    <remap from="odom" to="$(arg  odom_topic)"/>
+    <remap from="/move_base/HATebLocalPlannerROS/agents_states" to="/$(arg namespace)/move_base/HATebLocalPlannerROS/agents_states" />
+    <remap from="/move_base/GlobalPlanner/make_plan" to="/$(arg namespace)/move_base/GlobalPlanner/make_plan"/>
+    <param name="base_local_planner" value="hateb_local_planner/HATebLocalPlannerROS" />
+    <!-- <param name="GlobalPlanner/allow_unknown" value="true" /> -->
+  </node>
+
+
+  <!-- With namespace -->
+  <group unless="$(eval ''==arg('namespace'))">
+    <!-- Stage agents to /tracked_agents -->
+    <node name="agents" pkg="cohan_layers" type="agents_bridge.py" output="screen"/>
+
+    <!-- agent pose prediction, for the local-planning -->
+    <node pkg="agent_path_prediction" type="agent_path_prediction" name="agent_path_predict" output="screen" >
+      <remap from="map" to="/map"/>
+      <remap from="/$(arg namespace)/agent_path_predict/tracked_agents" to="/tracked_agents"/>
+      <remap from="/$(arg namespace)/agent_path_predict/external_agent_trajs" to="/move_base_node/HATebLocalPlannerROS/agent_local_trajs"/>
+
+      <param name="velobs_mul" value="1.0"/>
+      <param name="velscale_mul" value="2.0"/>
+      <!-- <param name="~robot_frame_id" value="burger_0_0_base_footprint"/> -->
+    </node>
+
+    <node pkg="agent_path_prediction" type="predict_goal.py" name="agent_goal_predict" output="screen">
+      <remap from="/tracked_agents" to="/$(arg namespace)/tracked_agents"/>
+    </node>
+
+    <!-- Filter the agents from laser scan -->
+    <include file="$(find cohan_layers)/launch/agent_filter.launch">
+      <arg name="simulator" value="stage"/>
+      <arg name="namespace" value="$(arg namespace)"/>
+    </include>
+  </group>
+</launch>

--- a/arena_bringup/launch/testing/move_base/move_base_crowdnav.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_crowdnav.launch
@@ -2,6 +2,9 @@
 <launch>
     <!-- move base -->
     <arg name="model" default="burger"/>
+    <arg name="cmd_vel_topic" default="cmd_vel"/>
+    <arg name="odom_topic" default="odom"/>
+    <arg name="namespace" />
     <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/local_costmap_params.yaml" command="load" />
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/global_costmap_params.yaml" command="load" />
@@ -12,11 +15,11 @@
 
     <arg name="speed" default="0.3"/>
     <!-- Launch neural net ros wrapper -->
-    <node pkg="crowdnav-ros" type="crowd_node_tb3.py" name="crowd_node" output="screen" ns="/crowd">
+    <node pkg="crowdnav-ros" type="crowd_node_tb3.py" name="crowd_node" output="screen">
         
         <!-- Publications -->
         <remap from="~other_vels" to="other_vels"/>
-        <remap from="~nn_cmd_vel" to="/cmd_vel"/>
+        <remap from="~nn_cmd_vel" to="cmd_vel"/>
         <remap from="~pose_marker" to="pose_marker"/>
         <remap from="~path_marker" to="path_marker"/>
         <remap from="~goal_path_marker" to="goal_path_marker"/>
@@ -24,12 +27,12 @@
         <remap from="~agent_markers" to="other_agents_markers"/>
         
         <!-- Subscriptions -->
-        <remap from="~pose" to="/odom"/>
+        <remap from="~pose" to="odom"/>
         <remap from="~velocity" to="velocity"/>
         <remap from="~safe_actions" to="local_path_finder/safe_actions"/>
         <remap from="~planner_mode" to="planner_fsm/mode"/>
-        <remap from="~goal" to="/goal"/>
-        <remap from="~subgoal" to="/subgoal"/>
+        <remap from="~goal" to="move_base_simple/goal"/>
+        <remap from="~subgoal" to="subgoal"/>
         <remap from="~clusters" to="/obst_odom"/>
         <remap from="~peds" to="ped_manager/ped_recent"/>
         
@@ -41,6 +44,8 @@
      <!-- spacial_horizon -->
      <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base/NavfnROS/make_plan" />
     </node>
 
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_dragon.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_dragon.launch
@@ -5,6 +5,7 @@
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
+  <arg name="namespace" />
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/arena_bringup/launch/testing/move_base/move_base_dwa.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_dwa.launch
@@ -4,7 +4,7 @@
   <arg name="model" default="burger"/>
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
-
+  <arg name="namespace" default="" />
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
     <param name="base_local_planner" value="dwa_local_planner/DWAPlannerROS" />

--- a/arena_bringup/launch/testing/move_base/move_base_lflh.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_lflh.launch
@@ -5,6 +5,7 @@
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
+  <arg name="namespace" default="" />
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/arena_bringup/launch/testing/move_base/move_base_mpc.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_mpc.launch
@@ -4,7 +4,7 @@
   <arg name="model" default="burger"/>
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
-
+  <arg name="namespace" default="" />
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/arena_bringup/launch/testing/move_base/move_base_rlca.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_rlca.launch
@@ -5,6 +5,7 @@
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
+  <arg name="namespace" default="" />
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
@@ -23,5 +24,7 @@
   <!-- spacial_horizon -->
   <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
     <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/plan_fsm_param.yaml" command="load" />
-     </node>
+    <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+    <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base/NavfnROS/make_plan" />
+  </node>
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_sarl.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_sarl.launch
@@ -2,6 +2,9 @@
 <launch>
     <!-- move base -->
     <arg name="model" default="burger"/>
+    <arg name="cmd_vel_topic" default="cmd_vel"/>
+    <arg name="odom_topic" default="odom"/>
+    <arg name="namespace" />
     <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/local_costmap_params.yaml" command="load" />
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/global_costmap_params.yaml" command="load" />
@@ -15,6 +18,8 @@
     <!-- spacial_horizon -->
     <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
         <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/costmaps/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base/NavfnROS/make_plan" />
     </node>
 
 </launch>

--- a/arena_bringup/launch/testing/move_base/move_base_trail.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_trail.launch
@@ -6,7 +6,7 @@
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
   <arg name="model_file"   default="$(find drl_vo_barn_nav)/src/model/drl_vo.zip"/>
-
+  <arg name="namespace" default="" />
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/arena_bringup/launch/testing/robot.launch
+++ b/arena_bringup/launch/testing/robot.launch
@@ -23,14 +23,17 @@
     <rosparam command="load" file="$(find arena-simulation-setup)/robot/$(arg model)/model_params.yaml" /> 
     <param name="robot_name" value="$(arg model)" />
     
-    <node pkg="tf2_ros" type="static_transform_publisher" name="transform_broadcaster" args="0 0 0 0 0 0 1 map $(arg namespace)_odom" />
+    <node pkg="tf2_ros" type="static_transform_publisher" name="transform_broadcaster" args="0 0 0 0 0 0 1 map $(arg namespace)/odom" />
 
-    <include 
-      file="$(find arena-simulation-setup)/robot/$(arg model)/launch/control.launch" 
-      if="$(eval env('ENVIRONMENT') == 'gazebo')"
-    >
-      <arg name="robot_namespace" value="$(arg namespace)" />
-    </include>
+    <group if="$(eval env('ENVIRONMENT') == 'gazebo')">
+        <include file="$(find arena-simulation-setup)/robot/$(arg model)/launch/control.launch">
+            <arg name="robot_namespace" value="$(arg namespace)" />
+        </include>
+        <node pkg="robot_state_publisher" type="robot_state_publisher" name="rob_st_pub" >
+            <remap from="/joint_states" to="$(arg namespace)/joint_states"/>
+        </node>
+    </group>
+  
 
     <!-- move_base plan manager: which provide basic global planner and cost map -->
     <include file="$(find arena_bringup)/launch/testing/move_base/move_base_$(arg local_planner).launch">
@@ -38,10 +41,10 @@
         <arg name="agent_name" value="$(arg agent_name)" if="$(eval arg('local_planner') == 'rosnav')" />
         
         <arg name="cmd_vel_topic" value="$(arg namespace)/cmd_vel" />
-        <arg name="odom_topic" value="$(arg namespace)/odom_topic" />
+        <arg name="odom_topic" value="$(arg namespace)/odom" />
 
         <arg name="namespace" value="$(arg namespace)" />
     </include>
 
-  </group>
+    </group>
 </launch>


### PR DESCRIPTION
-  Fixing topics/arguments in move_base launch files
- Adding cohan launch file
- Adding sensor_sim node to the main launch files
- Adding back robot state publisher when using Gazebo

Most importantly, changing frame prefix from the flatland default of  '_' to '/' used by ROS's robot state publisher. The schema for robot frames now looks like this : robot_i_i/frame. To achieve the same behavior in both simulators, I had to change flatland's code, and rename flatland bodies/scanner definitions to match those in the URDF files.
