### PR TITLE
Adding static transform node to AiO launch file

### DIFF
--- a/arena_bringup/launch/testing/move_base/move_base_aio.launch
+++ b/arena_bringup/launch/testing/move_base/move_base_aio.launch
@@ -12,6 +12,7 @@
 	</node>
 
 	<!-- Node to publish static scan (only based on robot position and map) -->
+	<node pkg="tf2_ros" type="static_transform_publisher" name="map_image_broadcaster" args="0 0 0 0 0 0  map map_image" />
 	<node name="light_scan_sim" pkg="light_scan_sim" type="light_scan_sim_node" output="screen">
 		<param name="laser/topic" value="/static_scan" />
 		<param name="laser/hz" value="20" />


### PR DESCRIPTION
This separate static_transform_publisher node replaces the current transform publisher in the light_scan_sim node itself. It fixes annoying frame duplicate warning.